### PR TITLE
feat: Add GitHub Actions workflow for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip build
+    - name: Build package
+      run: python -m build
+    - name: Publish package to GitHub Packages
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository_url: https://pypi.pkg.github.com/Anand-0037
+        user: __token__
+        password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the process of building and publishing the Python package to GitHub Packages.

The workflow is defined in `.github/workflows/publish.yml` and is configured to trigger automatically when a new release is published on GitHub. This ensures that every new version of the package is reliably uploaded to the GitHub Packages registry.